### PR TITLE
Check for prefix in BIG results and use it in name matching

### DIFF
--- a/src/main/java/foundation/privacybydesign/bigregister/RestApi.java
+++ b/src/main/java/foundation/privacybydesign/bigregister/RestApi.java
@@ -143,8 +143,19 @@ public class RestApi {
         }
 
         ListHcpApprox4 result = results.get(0);
-        if (!result.getBirthSurname().equals(familyName) ||
-                !result.getInitial().substring(0, 1).equals(initials.substring(0, 1))) {
+        boolean lastnameMatch = false;
+        if (result.getBirthSurname().equals(familyName)) {
+            // Lastname matches exactly.
+            lastnameMatch = true;
+        } else if (result.getPrefix() != null && (result.getPrefix() + " " + result.getBirthSurname()).equals(familyName)) {
+            // Lastname has a prefix. Banks often put the prefix in the lastname
+            // field, while for BIG it differs (see above). Sometimes, the
+            // prefix is inserted into the last name, sometimes it is a separate
+            // field. In this case, it is apparently a separate field in the BIG
+            // database.
+            lastnameMatch = true;
+        }
+        if (!lastnameMatch || !result.getInitial().substring(0, 1).equals(initials.substring(0, 1))) {
             // The 'familyName' is the birth family name, so we're OK here
             // even if people marry and change their last name.
             // The initial is a bit more difficult, I'm not sure people will always use the same initials.

--- a/src/main/java/foundation/privacybydesign/bigregister/RestApi.java
+++ b/src/main/java/foundation/privacybydesign/bigregister/RestApi.java
@@ -143,19 +143,16 @@ public class RestApi {
         }
 
         ListHcpApprox4 result = results.get(0);
-        boolean lastnameMatch = false;
-        if (result.getBirthSurname().equals(familyName)) {
-            // Lastname matches exactly.
-            lastnameMatch = true;
-        } else if (result.getPrefix() != null && (result.getPrefix() + " " + result.getBirthSurname()).equals(familyName)) {
+        String lastnameToMatch = result.getBirthSurname();
+        if (result.getPrefix() != null) {
             // Lastname has a prefix. Banks often put the prefix in the lastname
             // field, while for BIG it differs (see above). Sometimes, the
             // prefix is inserted into the last name, sometimes it is a separate
             // field. In this case, it is apparently a separate field in the BIG
             // database.
-            lastnameMatch = true;
+            lastnameToMatch = result.getPrefix() + " " + result.getBirthSurname();
         }
-        if (!lastnameMatch || !result.getInitial().substring(0, 1).equals(initials.substring(0, 1))) {
+        if (!lastnameToMatch.equals(familyName) || !result.getInitial().substring(0, 1).equals(initials.substring(0, 1))) {
             // The 'familyName' is the birth family name, so we're OK here
             // even if people marry and change their last name.
             // The initial is a bit more difficult, I'm not sure people will always use the same initials.


### PR DESCRIPTION
Not 100% confirmed this is an issue, but it probably is.
For some (newer?) entries in the BIG database, the prefix is saved in a separate field, while banks usually join the prefix and last name.
This PR also tries to match the name with the prefix attached.

Note: should we perhaps only check with the prefix attached? I don't think there will be much harm in checking both options.